### PR TITLE
When pulling changes from an existing repository also pull them from all the submodules

### DIFF
--- a/build_toolchain.sh
+++ b/build_toolchain.sh
@@ -45,7 +45,7 @@ function update_repo {
   URL=$2
   if [ -d ./deps/$NAME ];
   then
-    cd ./deps/$NAME && git pull
+    cd ./deps/$NAME && git pull --recurse-submodules=yes
   else
     git clone --recursive $URL deps/$NAME
   fi


### PR DESCRIPTION
This bit me today as the librustc checkout was out of date and prevented me from building an updated toolchain
